### PR TITLE
respect log level

### DIFF
--- a/dist/applied-logger.cjs.js
+++ b/dist/applied-logger.cjs.js
@@ -3302,10 +3302,8 @@ var Formatter = function () {
                 formattedQuery = _this.formatComma(token, formattedQuery);
             } else if (token.value === ":") {
                 formattedQuery = _this.formatWithSpaceAfter(token, formattedQuery);
-            } else if (token.value === ".") {
+            } else if (token.value === "." || token.value === ";") {
                 formattedQuery = _this.formatWithoutSpaces(token, formattedQuery);
-            } else if (token.value === ";") {
-                formattedQuery = _this.formatQuerySeparator(token, formattedQuery);
             } else {
                 formattedQuery = _this.formatWithSpaces(token, formattedQuery);
             }
@@ -3410,10 +3408,6 @@ var Formatter = function () {
 
     Formatter.prototype.formatWithSpaces = function formatWithSpaces(token, query) {
         return query + token.value + " ";
-    };
-
-    Formatter.prototype.formatQuerySeparator = function formatQuerySeparator(token, query) {
-        return this.trimTrailingWhitespace(query) + token.value + "\n";
     };
 
     Formatter.prototype.addNewline = function addNewline(query) {
@@ -3789,7 +3783,7 @@ var stubFalse_1 = stubFalse;
 
 var isBuffer_1 = createCommonjsModule(function (module, exports) {
 /** Detect free variable `exports`. */
-var freeExports =  exports && !exports.nodeType && exports;
+var freeExports = exports && !exports.nodeType && exports;
 
 /** Detect free variable `module`. */
 var freeModule = freeExports && 'object' == 'object' && module && !module.nodeType && module;
@@ -3899,7 +3893,7 @@ var _baseUnary = baseUnary;
 
 var _nodeUtil = createCommonjsModule(function (module, exports) {
 /** Detect free variable `exports`. */
-var freeExports =  exports && !exports.nodeType && exports;
+var freeExports = exports && !exports.nodeType && exports;
 
 /** Detect free variable `module`. */
 var freeModule = freeExports && 'object' == 'object' && module && !module.nodeType && module;
@@ -4777,6 +4771,365 @@ var getTokens = function getTokens(json, options = {}) {
 var lexer = {
 	getTokens: getTokens
 };
+
+const TEMPLATE_REGEX$1 = /(?:\\(u[a-f\d]{4}|x[a-f\d]{2}|.))|(?:\{(~)?(\w+(?:\([^)]*\))?(?:\.\w+(?:\([^)]*\))?)*)(?:[ \t]|(?=\r?\n)))|(\})|((?:.|[\r\n\f])+?)/gi;
+const STYLE_REGEX$1 = /(?:^|\.)(\w+)(?:\(([^)]*)\))?/g;
+const STRING_REGEX$1 = /^(['"])((?:\\.|(?!\1)[^\\])*)\1$/;
+const ESCAPE_REGEX$1 = /\\(u[a-f\d]{4}|x[a-f\d]{2}|.)|([^\\])/gi;
+
+const ESCAPES$1 = new Map([
+	['n', '\n'],
+	['r', '\r'],
+	['t', '\t'],
+	['b', '\b'],
+	['f', '\f'],
+	['v', '\v'],
+	['0', '\0'],
+	['\\', '\\'],
+	['e', '\u001B'],
+	['a', '\u0007']
+]);
+
+function unescape$1(c) {
+	if ((c[0] === 'u' && c.length === 5) || (c[0] === 'x' && c.length === 3)) {
+		return String.fromCharCode(parseInt(c.slice(1), 16));
+	}
+
+	return ESCAPES$1.get(c) || c;
+}
+
+function parseArguments$1(name, args) {
+	const results = [];
+	const chunks = args.trim().split(/\s*,\s*/g);
+	let matches;
+
+	for (const chunk of chunks) {
+		if (!isNaN(chunk)) {
+			results.push(Number(chunk));
+		} else if ((matches = chunk.match(STRING_REGEX$1))) {
+			results.push(matches[2].replace(ESCAPE_REGEX$1, (m, escape, chr) => escape ? unescape$1(escape) : chr));
+		} else {
+			throw new Error(`Invalid Chalk template style argument: ${chunk} (in style '${name}')`);
+		}
+	}
+
+	return results;
+}
+
+function parseStyle$1(style) {
+	STYLE_REGEX$1.lastIndex = 0;
+
+	const results = [];
+	let matches;
+
+	while ((matches = STYLE_REGEX$1.exec(style)) !== null) {
+		const name = matches[1];
+
+		if (matches[2]) {
+			const args = parseArguments$1(name, matches[2]);
+			results.push([name].concat(args));
+		} else {
+			results.push([name]);
+		}
+	}
+
+	return results;
+}
+
+function buildStyle$1(chalk, styles) {
+	const enabled = {};
+
+	for (const layer of styles) {
+		for (const style of layer.styles) {
+			enabled[style[0]] = layer.inverse ? null : style.slice(1);
+		}
+	}
+
+	let current = chalk;
+	for (const styleName of Object.keys(enabled)) {
+		if (Array.isArray(enabled[styleName])) {
+			if (!(styleName in current)) {
+				throw new Error(`Unknown Chalk style: ${styleName}`);
+			}
+
+			if (enabled[styleName].length > 0) {
+				current = current[styleName].apply(current, enabled[styleName]);
+			} else {
+				current = current[styleName];
+			}
+		}
+	}
+
+	return current;
+}
+
+var templates$1 = (chalk, tmp) => {
+	const styles = [];
+	const chunks = [];
+	let chunk = [];
+
+	// eslint-disable-next-line max-params
+	tmp.replace(TEMPLATE_REGEX$1, (m, escapeChar, inverse, style, close, chr) => {
+		if (escapeChar) {
+			chunk.push(unescape$1(escapeChar));
+		} else if (style) {
+			const str = chunk.join('');
+			chunk = [];
+			chunks.push(styles.length === 0 ? str : buildStyle$1(chalk, styles)(str));
+			styles.push({inverse, styles: parseStyle$1(style)});
+		} else if (close) {
+			if (styles.length === 0) {
+				throw new Error('Found extraneous } in Chalk template literal');
+			}
+
+			chunks.push(buildStyle$1(chalk, styles)(chunk.join('')));
+			chunk = [];
+			styles.pop();
+		} else {
+			chunk.push(chr);
+		}
+	});
+
+	chunks.push(chunk.join(''));
+
+	if (styles.length > 0) {
+		const errMsg = `Chalk template literal is missing ${styles.length} closing bracket${styles.length === 1 ? '' : 's'} (\`}\`)`;
+		throw new Error(errMsg);
+	}
+
+	return chunks.join('');
+};
+
+var chalk$1 = createCommonjsModule(function (module) {
+
+
+const stdoutColor = supportsColor_1.stdout;
+
+
+
+const isSimpleWindowsTerm = process.platform === 'win32' && !(process.env.TERM || '').toLowerCase().startsWith('xterm');
+
+// `supportsColor.level` → `ansiStyles.color[name]` mapping
+const levelMapping = ['ansi', 'ansi', 'ansi256', 'ansi16m'];
+
+// `color-convert` models to exclude from the Chalk API due to conflicts and such
+const skipModels = new Set(['gray']);
+
+const styles = Object.create(null);
+
+function applyOptions(obj, options) {
+	options = options || {};
+
+	// Detect level if not set manually
+	const scLevel = stdoutColor ? stdoutColor.level : 0;
+	obj.level = options.level === undefined ? scLevel : options.level;
+	obj.enabled = 'enabled' in options ? options.enabled : obj.level > 0;
+}
+
+function Chalk(options) {
+	// We check for this.template here since calling `chalk.constructor()`
+	// by itself will have a `this` of a previously constructed chalk object
+	if (!this || !(this instanceof Chalk) || this.template) {
+		const chalk = {};
+		applyOptions(chalk, options);
+
+		chalk.template = function () {
+			const args = [].slice.call(arguments);
+			return chalkTag.apply(null, [chalk.template].concat(args));
+		};
+
+		Object.setPrototypeOf(chalk, Chalk.prototype);
+		Object.setPrototypeOf(chalk.template, chalk);
+
+		chalk.template.constructor = Chalk;
+
+		return chalk.template;
+	}
+
+	applyOptions(this, options);
+}
+
+// Use bright blue on Windows as the normal blue color is illegible
+if (isSimpleWindowsTerm) {
+	ansiStyles.blue.open = '\u001B[94m';
+}
+
+for (const key of Object.keys(ansiStyles)) {
+	ansiStyles[key].closeRe = new RegExp(escapeStringRegexp(ansiStyles[key].close), 'g');
+
+	styles[key] = {
+		get() {
+			const codes = ansiStyles[key];
+			return build.call(this, this._styles ? this._styles.concat(codes) : [codes], this._empty, key);
+		}
+	};
+}
+
+styles.visible = {
+	get() {
+		return build.call(this, this._styles || [], true, 'visible');
+	}
+};
+
+ansiStyles.color.closeRe = new RegExp(escapeStringRegexp(ansiStyles.color.close), 'g');
+for (const model of Object.keys(ansiStyles.color.ansi)) {
+	if (skipModels.has(model)) {
+		continue;
+	}
+
+	styles[model] = {
+		get() {
+			const level = this.level;
+			return function () {
+				const open = ansiStyles.color[levelMapping[level]][model].apply(null, arguments);
+				const codes = {
+					open,
+					close: ansiStyles.color.close,
+					closeRe: ansiStyles.color.closeRe
+				};
+				return build.call(this, this._styles ? this._styles.concat(codes) : [codes], this._empty, model);
+			};
+		}
+	};
+}
+
+ansiStyles.bgColor.closeRe = new RegExp(escapeStringRegexp(ansiStyles.bgColor.close), 'g');
+for (const model of Object.keys(ansiStyles.bgColor.ansi)) {
+	if (skipModels.has(model)) {
+		continue;
+	}
+
+	const bgModel = 'bg' + model[0].toUpperCase() + model.slice(1);
+	styles[bgModel] = {
+		get() {
+			const level = this.level;
+			return function () {
+				const open = ansiStyles.bgColor[levelMapping[level]][model].apply(null, arguments);
+				const codes = {
+					open,
+					close: ansiStyles.bgColor.close,
+					closeRe: ansiStyles.bgColor.closeRe
+				};
+				return build.call(this, this._styles ? this._styles.concat(codes) : [codes], this._empty, model);
+			};
+		}
+	};
+}
+
+const proto = Object.defineProperties(() => {}, styles);
+
+function build(_styles, _empty, key) {
+	const builder = function () {
+		return applyStyle.apply(builder, arguments);
+	};
+
+	builder._styles = _styles;
+	builder._empty = _empty;
+
+	const self = this;
+
+	Object.defineProperty(builder, 'level', {
+		enumerable: true,
+		get() {
+			return self.level;
+		},
+		set(level) {
+			self.level = level;
+		}
+	});
+
+	Object.defineProperty(builder, 'enabled', {
+		enumerable: true,
+		get() {
+			return self.enabled;
+		},
+		set(enabled) {
+			self.enabled = enabled;
+		}
+	});
+
+	// See below for fix regarding invisible grey/dim combination on Windows
+	builder.hasGrey = this.hasGrey || key === 'gray' || key === 'grey';
+
+	// `__proto__` is used because we must return a function, but there is
+	// no way to create a function with a different prototype
+	builder.__proto__ = proto; // eslint-disable-line no-proto
+
+	return builder;
+}
+
+function applyStyle() {
+	// Support varags, but simply cast to string in case there's only one arg
+	const args = arguments;
+	const argsLen = args.length;
+	let str = String(arguments[0]);
+
+	if (argsLen === 0) {
+		return '';
+	}
+
+	if (argsLen > 1) {
+		// Don't slice `arguments`, it prevents V8 optimizations
+		for (let a = 1; a < argsLen; a++) {
+			str += ' ' + args[a];
+		}
+	}
+
+	if (!this.enabled || this.level <= 0 || !str) {
+		return this._empty ? '' : str;
+	}
+
+	// Turns out that on Windows dimmed gray text becomes invisible in cmd.exe,
+	// see https://github.com/chalk/chalk/issues/58
+	// If we're on Windows and we're dealing with a gray color, temporarily make 'dim' a noop.
+	const originalDim = ansiStyles.dim.open;
+	if (isSimpleWindowsTerm && this.hasGrey) {
+		ansiStyles.dim.open = '';
+	}
+
+	for (const code of this._styles.slice().reverse()) {
+		// Replace any instances already present with a re-opening code
+		// otherwise only the part of the string until said closing code
+		// will be colored, and the rest will simply be 'plain'.
+		str = code.open + str.replace(code.closeRe, code.open) + code.close;
+
+		// Close the styling before a linebreak and reopen
+		// after next line to fix a bleed issue on macOS
+		// https://github.com/chalk/chalk/pull/92
+		str = str.replace(/\r?\n/g, `${code.close}$&${code.open}`);
+	}
+
+	// Reset the original `dim` if we changed it to work around the Windows dimmed gray issue
+	ansiStyles.dim.open = originalDim;
+
+	return str;
+}
+
+function chalkTag(chalk, strings) {
+	if (!Array.isArray(strings)) {
+		// If chalk() was called by itself or with a string,
+		// return the string itself as a string.
+		return [].slice.call(arguments, 1).join(' ');
+	}
+
+	const args = [].slice.call(arguments, 2);
+	const parts = [strings.raw[0]];
+
+	for (let i = 1; i < strings.length; i++) {
+		parts.push(String(args[i - 1]).replace(/[{}\\]/g, '\\$&'));
+		parts.push(String(strings.raw[i]));
+	}
+
+	return templates$1(chalk, parts.join(''));
+}
+
+Object.defineProperties(Chalk.prototype, styles);
+
+module.exports = Chalk(); // eslint-disable-line new-cap
+module.exports.supportsColor = stdoutColor;
+module.exports.default = module.exports; // For TypeScript
+});
+var chalk_1$1 = chalk$1.supportsColor;
 
 /**
  * lodash (Custom Build) <https://lodash.com/>
@@ -5727,7 +6080,7 @@ var colorize = function colorize(tokens, options = {}) {
 
   return tokens.reduce((acc, token) => {
     const colorKey = colors[token.type] || defaultColors[token.type];
-    const colorFn = colorKey && colorKey[0] === '#' ? chalk.hex(colorKey) : lodash_get(chalk, colorKey);
+    const colorFn = colorKey && colorKey[0] === '#' ? chalk$1.hex(colorKey) : lodash_get(chalk$1, colorKey);
 
     return acc + (colorFn ? colorFn(token.value) : token.value);
   }, '');
@@ -5746,37 +6099,37 @@ var lib = function colorizeJson(json, options) {
 
 
 var config = {
-    error: {
+    ERROR: {
         function: chalk.red,
         text: "🤯   [ERROR] ",
         console: message => { console.error(message); }
     },
 
-    warn: {
+    WARN: {
         function: chalk.yellow,
         text: "⚠️   [WARN]  ",
         console: message => { console.warn(message); }
     },
 
-    debug: {
+    DEBUG: {
         function: chalk.blue,
         text: "🕵️‍   [DEBUG] ",
         console: message => { console.log(message); }
     },
 
-    info: {
+    INFO: {
         function: chalk.green,
         text: "🧙‍   [INFO]  ",
         console: message => { console.info(message); }
     },
 
-    sql: {
+    SQL: {
         function: chalk.grey,
         text: "[SQLIZE] ",
         console: message => { console.log(message); }
     },
 
-    log: {
+    LOG: {
         function: chalk.magenta,
         text: "🌳  [LOG]   ",
         console: message => { console.log(message); }
@@ -5807,13 +6160,13 @@ exports.JSONifier = input => {
     return lib(input, { pretty: true })
 };
 
-exports.constuctError = (err, req) => {
+exports.constructError = (type, err, req) => {
     const errJson = {
         name: err.name,
         message: err.message,
         stack: err.stack,
         context: err.context,
-        status: "ERROR"
+        status: type
     };
 
     if (req) {
@@ -5835,17 +6188,16 @@ exports.checkForSpecifiError = inputs => {
     return inputs.length === 2 && inputs[0] instanceof Error && !!inputs[1].url
 };
 
-exports.printer = (colorKey, input) => { /* eslint-disable-line consistent-return */
+exports.printer = (type, input) => { /* eslint-disable-line consistent-return */
+    if(!config[type]) return exports.JSONifier(input)
 
-    if(!config[colorKey]) return exports.JSONifier(input)
-
-    config[colorKey].console(
-        config[colorKey].function(`${config[colorKey].text} ${exports.JSONifier(input)}`)
+    config[type].console(
+        config[type].function(`${config[type].text} ${exports.JSONifier(input)}`)
     );
 };
 });
 var utils_1 = utils.JSONifier;
-var utils_2 = utils.constuctError;
+var utils_2 = utils.constructError;
 var utils_3 = utils.checkForSpecifiError;
 var utils_4 = utils.printer;
 
@@ -5857,7 +6209,7 @@ var utils_4 = utils.printer;
 
 const baseLog = (type, inputs) => {
     if (utils.checkForSpecifiError(inputs)) {
-        utils.printer(type, utils.constuctError(inputs[0], inputs[1]));
+        utils.printer(type, utils.constructError(type, inputs[0], inputs[1]));
     } else {
         inputs.forEach(arg => {
             utils.printer(type, arg);
@@ -5865,15 +6217,15 @@ const baseLog = (type, inputs) => {
     }
 };
 
-var error = (...inputs) => baseLog('error', inputs); 
+var error = (...inputs) => baseLog('ERROR', inputs); 
 
-var warn = (...inputs) => baseLog('warn', inputs); 
+var warn = (...inputs) => baseLog('WARN', inputs); 
 
-var info = (...inputs) => baseLog('info', inputs); 
+var info = (...inputs) => baseLog('INFO', inputs); 
 
-var log = (...inputs) => baseLog('log', inputs); 
+var log = (...inputs) => baseLog('LOG', inputs); 
 
-var debug = (...inputs) => baseLog('debug', inputs); 
+var debug = (...inputs) => baseLog('DEBUG', inputs); 
 
 // only bespoke thing
 var sql = (...inputs) => {

--- a/dist/applied-logger.esm.js
+++ b/dist/applied-logger.esm.js
@@ -3296,10 +3296,8 @@ var Formatter = function () {
                 formattedQuery = _this.formatComma(token, formattedQuery);
             } else if (token.value === ":") {
                 formattedQuery = _this.formatWithSpaceAfter(token, formattedQuery);
-            } else if (token.value === ".") {
+            } else if (token.value === "." || token.value === ";") {
                 formattedQuery = _this.formatWithoutSpaces(token, formattedQuery);
-            } else if (token.value === ";") {
-                formattedQuery = _this.formatQuerySeparator(token, formattedQuery);
             } else {
                 formattedQuery = _this.formatWithSpaces(token, formattedQuery);
             }
@@ -3404,10 +3402,6 @@ var Formatter = function () {
 
     Formatter.prototype.formatWithSpaces = function formatWithSpaces(token, query) {
         return query + token.value + " ";
-    };
-
-    Formatter.prototype.formatQuerySeparator = function formatQuerySeparator(token, query) {
-        return this.trimTrailingWhitespace(query) + token.value + "\n";
     };
 
     Formatter.prototype.addNewline = function addNewline(query) {
@@ -3783,7 +3777,7 @@ var stubFalse_1 = stubFalse;
 
 var isBuffer_1 = createCommonjsModule(function (module, exports) {
 /** Detect free variable `exports`. */
-var freeExports =  exports && !exports.nodeType && exports;
+var freeExports = exports && !exports.nodeType && exports;
 
 /** Detect free variable `module`. */
 var freeModule = freeExports && 'object' == 'object' && module && !module.nodeType && module;
@@ -3893,7 +3887,7 @@ var _baseUnary = baseUnary;
 
 var _nodeUtil = createCommonjsModule(function (module, exports) {
 /** Detect free variable `exports`. */
-var freeExports =  exports && !exports.nodeType && exports;
+var freeExports = exports && !exports.nodeType && exports;
 
 /** Detect free variable `module`. */
 var freeModule = freeExports && 'object' == 'object' && module && !module.nodeType && module;
@@ -4771,6 +4765,365 @@ var getTokens = function getTokens(json, options = {}) {
 var lexer = {
 	getTokens: getTokens
 };
+
+const TEMPLATE_REGEX$1 = /(?:\\(u[a-f\d]{4}|x[a-f\d]{2}|.))|(?:\{(~)?(\w+(?:\([^)]*\))?(?:\.\w+(?:\([^)]*\))?)*)(?:[ \t]|(?=\r?\n)))|(\})|((?:.|[\r\n\f])+?)/gi;
+const STYLE_REGEX$1 = /(?:^|\.)(\w+)(?:\(([^)]*)\))?/g;
+const STRING_REGEX$1 = /^(['"])((?:\\.|(?!\1)[^\\])*)\1$/;
+const ESCAPE_REGEX$1 = /\\(u[a-f\d]{4}|x[a-f\d]{2}|.)|([^\\])/gi;
+
+const ESCAPES$1 = new Map([
+	['n', '\n'],
+	['r', '\r'],
+	['t', '\t'],
+	['b', '\b'],
+	['f', '\f'],
+	['v', '\v'],
+	['0', '\0'],
+	['\\', '\\'],
+	['e', '\u001B'],
+	['a', '\u0007']
+]);
+
+function unescape$1(c) {
+	if ((c[0] === 'u' && c.length === 5) || (c[0] === 'x' && c.length === 3)) {
+		return String.fromCharCode(parseInt(c.slice(1), 16));
+	}
+
+	return ESCAPES$1.get(c) || c;
+}
+
+function parseArguments$1(name, args) {
+	const results = [];
+	const chunks = args.trim().split(/\s*,\s*/g);
+	let matches;
+
+	for (const chunk of chunks) {
+		if (!isNaN(chunk)) {
+			results.push(Number(chunk));
+		} else if ((matches = chunk.match(STRING_REGEX$1))) {
+			results.push(matches[2].replace(ESCAPE_REGEX$1, (m, escape, chr) => escape ? unescape$1(escape) : chr));
+		} else {
+			throw new Error(`Invalid Chalk template style argument: ${chunk} (in style '${name}')`);
+		}
+	}
+
+	return results;
+}
+
+function parseStyle$1(style) {
+	STYLE_REGEX$1.lastIndex = 0;
+
+	const results = [];
+	let matches;
+
+	while ((matches = STYLE_REGEX$1.exec(style)) !== null) {
+		const name = matches[1];
+
+		if (matches[2]) {
+			const args = parseArguments$1(name, matches[2]);
+			results.push([name].concat(args));
+		} else {
+			results.push([name]);
+		}
+	}
+
+	return results;
+}
+
+function buildStyle$1(chalk, styles) {
+	const enabled = {};
+
+	for (const layer of styles) {
+		for (const style of layer.styles) {
+			enabled[style[0]] = layer.inverse ? null : style.slice(1);
+		}
+	}
+
+	let current = chalk;
+	for (const styleName of Object.keys(enabled)) {
+		if (Array.isArray(enabled[styleName])) {
+			if (!(styleName in current)) {
+				throw new Error(`Unknown Chalk style: ${styleName}`);
+			}
+
+			if (enabled[styleName].length > 0) {
+				current = current[styleName].apply(current, enabled[styleName]);
+			} else {
+				current = current[styleName];
+			}
+		}
+	}
+
+	return current;
+}
+
+var templates$1 = (chalk, tmp) => {
+	const styles = [];
+	const chunks = [];
+	let chunk = [];
+
+	// eslint-disable-next-line max-params
+	tmp.replace(TEMPLATE_REGEX$1, (m, escapeChar, inverse, style, close, chr) => {
+		if (escapeChar) {
+			chunk.push(unescape$1(escapeChar));
+		} else if (style) {
+			const str = chunk.join('');
+			chunk = [];
+			chunks.push(styles.length === 0 ? str : buildStyle$1(chalk, styles)(str));
+			styles.push({inverse, styles: parseStyle$1(style)});
+		} else if (close) {
+			if (styles.length === 0) {
+				throw new Error('Found extraneous } in Chalk template literal');
+			}
+
+			chunks.push(buildStyle$1(chalk, styles)(chunk.join('')));
+			chunk = [];
+			styles.pop();
+		} else {
+			chunk.push(chr);
+		}
+	});
+
+	chunks.push(chunk.join(''));
+
+	if (styles.length > 0) {
+		const errMsg = `Chalk template literal is missing ${styles.length} closing bracket${styles.length === 1 ? '' : 's'} (\`}\`)`;
+		throw new Error(errMsg);
+	}
+
+	return chunks.join('');
+};
+
+var chalk$1 = createCommonjsModule(function (module) {
+
+
+const stdoutColor = supportsColor_1.stdout;
+
+
+
+const isSimpleWindowsTerm = process.platform === 'win32' && !(process.env.TERM || '').toLowerCase().startsWith('xterm');
+
+// `supportsColor.level` → `ansiStyles.color[name]` mapping
+const levelMapping = ['ansi', 'ansi', 'ansi256', 'ansi16m'];
+
+// `color-convert` models to exclude from the Chalk API due to conflicts and such
+const skipModels = new Set(['gray']);
+
+const styles = Object.create(null);
+
+function applyOptions(obj, options) {
+	options = options || {};
+
+	// Detect level if not set manually
+	const scLevel = stdoutColor ? stdoutColor.level : 0;
+	obj.level = options.level === undefined ? scLevel : options.level;
+	obj.enabled = 'enabled' in options ? options.enabled : obj.level > 0;
+}
+
+function Chalk(options) {
+	// We check for this.template here since calling `chalk.constructor()`
+	// by itself will have a `this` of a previously constructed chalk object
+	if (!this || !(this instanceof Chalk) || this.template) {
+		const chalk = {};
+		applyOptions(chalk, options);
+
+		chalk.template = function () {
+			const args = [].slice.call(arguments);
+			return chalkTag.apply(null, [chalk.template].concat(args));
+		};
+
+		Object.setPrototypeOf(chalk, Chalk.prototype);
+		Object.setPrototypeOf(chalk.template, chalk);
+
+		chalk.template.constructor = Chalk;
+
+		return chalk.template;
+	}
+
+	applyOptions(this, options);
+}
+
+// Use bright blue on Windows as the normal blue color is illegible
+if (isSimpleWindowsTerm) {
+	ansiStyles.blue.open = '\u001B[94m';
+}
+
+for (const key of Object.keys(ansiStyles)) {
+	ansiStyles[key].closeRe = new RegExp(escapeStringRegexp(ansiStyles[key].close), 'g');
+
+	styles[key] = {
+		get() {
+			const codes = ansiStyles[key];
+			return build.call(this, this._styles ? this._styles.concat(codes) : [codes], this._empty, key);
+		}
+	};
+}
+
+styles.visible = {
+	get() {
+		return build.call(this, this._styles || [], true, 'visible');
+	}
+};
+
+ansiStyles.color.closeRe = new RegExp(escapeStringRegexp(ansiStyles.color.close), 'g');
+for (const model of Object.keys(ansiStyles.color.ansi)) {
+	if (skipModels.has(model)) {
+		continue;
+	}
+
+	styles[model] = {
+		get() {
+			const level = this.level;
+			return function () {
+				const open = ansiStyles.color[levelMapping[level]][model].apply(null, arguments);
+				const codes = {
+					open,
+					close: ansiStyles.color.close,
+					closeRe: ansiStyles.color.closeRe
+				};
+				return build.call(this, this._styles ? this._styles.concat(codes) : [codes], this._empty, model);
+			};
+		}
+	};
+}
+
+ansiStyles.bgColor.closeRe = new RegExp(escapeStringRegexp(ansiStyles.bgColor.close), 'g');
+for (const model of Object.keys(ansiStyles.bgColor.ansi)) {
+	if (skipModels.has(model)) {
+		continue;
+	}
+
+	const bgModel = 'bg' + model[0].toUpperCase() + model.slice(1);
+	styles[bgModel] = {
+		get() {
+			const level = this.level;
+			return function () {
+				const open = ansiStyles.bgColor[levelMapping[level]][model].apply(null, arguments);
+				const codes = {
+					open,
+					close: ansiStyles.bgColor.close,
+					closeRe: ansiStyles.bgColor.closeRe
+				};
+				return build.call(this, this._styles ? this._styles.concat(codes) : [codes], this._empty, model);
+			};
+		}
+	};
+}
+
+const proto = Object.defineProperties(() => {}, styles);
+
+function build(_styles, _empty, key) {
+	const builder = function () {
+		return applyStyle.apply(builder, arguments);
+	};
+
+	builder._styles = _styles;
+	builder._empty = _empty;
+
+	const self = this;
+
+	Object.defineProperty(builder, 'level', {
+		enumerable: true,
+		get() {
+			return self.level;
+		},
+		set(level) {
+			self.level = level;
+		}
+	});
+
+	Object.defineProperty(builder, 'enabled', {
+		enumerable: true,
+		get() {
+			return self.enabled;
+		},
+		set(enabled) {
+			self.enabled = enabled;
+		}
+	});
+
+	// See below for fix regarding invisible grey/dim combination on Windows
+	builder.hasGrey = this.hasGrey || key === 'gray' || key === 'grey';
+
+	// `__proto__` is used because we must return a function, but there is
+	// no way to create a function with a different prototype
+	builder.__proto__ = proto; // eslint-disable-line no-proto
+
+	return builder;
+}
+
+function applyStyle() {
+	// Support varags, but simply cast to string in case there's only one arg
+	const args = arguments;
+	const argsLen = args.length;
+	let str = String(arguments[0]);
+
+	if (argsLen === 0) {
+		return '';
+	}
+
+	if (argsLen > 1) {
+		// Don't slice `arguments`, it prevents V8 optimizations
+		for (let a = 1; a < argsLen; a++) {
+			str += ' ' + args[a];
+		}
+	}
+
+	if (!this.enabled || this.level <= 0 || !str) {
+		return this._empty ? '' : str;
+	}
+
+	// Turns out that on Windows dimmed gray text becomes invisible in cmd.exe,
+	// see https://github.com/chalk/chalk/issues/58
+	// If we're on Windows and we're dealing with a gray color, temporarily make 'dim' a noop.
+	const originalDim = ansiStyles.dim.open;
+	if (isSimpleWindowsTerm && this.hasGrey) {
+		ansiStyles.dim.open = '';
+	}
+
+	for (const code of this._styles.slice().reverse()) {
+		// Replace any instances already present with a re-opening code
+		// otherwise only the part of the string until said closing code
+		// will be colored, and the rest will simply be 'plain'.
+		str = code.open + str.replace(code.closeRe, code.open) + code.close;
+
+		// Close the styling before a linebreak and reopen
+		// after next line to fix a bleed issue on macOS
+		// https://github.com/chalk/chalk/pull/92
+		str = str.replace(/\r?\n/g, `${code.close}$&${code.open}`);
+	}
+
+	// Reset the original `dim` if we changed it to work around the Windows dimmed gray issue
+	ansiStyles.dim.open = originalDim;
+
+	return str;
+}
+
+function chalkTag(chalk, strings) {
+	if (!Array.isArray(strings)) {
+		// If chalk() was called by itself or with a string,
+		// return the string itself as a string.
+		return [].slice.call(arguments, 1).join(' ');
+	}
+
+	const args = [].slice.call(arguments, 2);
+	const parts = [strings.raw[0]];
+
+	for (let i = 1; i < strings.length; i++) {
+		parts.push(String(args[i - 1]).replace(/[{}\\]/g, '\\$&'));
+		parts.push(String(strings.raw[i]));
+	}
+
+	return templates$1(chalk, parts.join(''));
+}
+
+Object.defineProperties(Chalk.prototype, styles);
+
+module.exports = Chalk(); // eslint-disable-line new-cap
+module.exports.supportsColor = stdoutColor;
+module.exports.default = module.exports; // For TypeScript
+});
+var chalk_1$1 = chalk$1.supportsColor;
 
 /**
  * lodash (Custom Build) <https://lodash.com/>
@@ -5721,7 +6074,7 @@ var colorize = function colorize(tokens, options = {}) {
 
   return tokens.reduce((acc, token) => {
     const colorKey = colors[token.type] || defaultColors[token.type];
-    const colorFn = colorKey && colorKey[0] === '#' ? chalk.hex(colorKey) : lodash_get(chalk, colorKey);
+    const colorFn = colorKey && colorKey[0] === '#' ? chalk$1.hex(colorKey) : lodash_get(chalk$1, colorKey);
 
     return acc + (colorFn ? colorFn(token.value) : token.value);
   }, '');
@@ -5740,37 +6093,37 @@ var lib = function colorizeJson(json, options) {
 
 
 var config = {
-    error: {
+    ERROR: {
         function: chalk.red,
         text: "🤯   [ERROR] ",
         console: message => { console.error(message); }
     },
 
-    warn: {
+    WARN: {
         function: chalk.yellow,
         text: "⚠️   [WARN]  ",
         console: message => { console.warn(message); }
     },
 
-    debug: {
+    DEBUG: {
         function: chalk.blue,
         text: "🕵️‍   [DEBUG] ",
         console: message => { console.log(message); }
     },
 
-    info: {
+    INFO: {
         function: chalk.green,
         text: "🧙‍   [INFO]  ",
         console: message => { console.info(message); }
     },
 
-    sql: {
+    SQL: {
         function: chalk.grey,
         text: "[SQLIZE] ",
         console: message => { console.log(message); }
     },
 
-    log: {
+    LOG: {
         function: chalk.magenta,
         text: "🌳  [LOG]   ",
         console: message => { console.log(message); }
@@ -5801,13 +6154,13 @@ exports.JSONifier = input => {
     return lib(input, { pretty: true })
 };
 
-exports.constuctError = (err, req) => {
+exports.constructError = (type, err, req) => {
     const errJson = {
         name: err.name,
         message: err.message,
         stack: err.stack,
         context: err.context,
-        status: "ERROR"
+        status: type
     };
 
     if (req) {
@@ -5829,17 +6182,16 @@ exports.checkForSpecifiError = inputs => {
     return inputs.length === 2 && inputs[0] instanceof Error && !!inputs[1].url
 };
 
-exports.printer = (colorKey, input) => { /* eslint-disable-line consistent-return */
+exports.printer = (type, input) => { /* eslint-disable-line consistent-return */
+    if(!config[type]) return exports.JSONifier(input)
 
-    if(!config[colorKey]) return exports.JSONifier(input)
-
-    config[colorKey].console(
-        config[colorKey].function(`${config[colorKey].text} ${exports.JSONifier(input)}`)
+    config[type].console(
+        config[type].function(`${config[type].text} ${exports.JSONifier(input)}`)
     );
 };
 });
 var utils_1 = utils.JSONifier;
-var utils_2 = utils.constuctError;
+var utils_2 = utils.constructError;
 var utils_3 = utils.checkForSpecifiError;
 var utils_4 = utils.printer;
 
@@ -5851,7 +6203,7 @@ var utils_4 = utils.printer;
 
 const baseLog = (type, inputs) => {
     if (utils.checkForSpecifiError(inputs)) {
-        utils.printer(type, utils.constuctError(inputs[0], inputs[1]));
+        utils.printer(type, utils.constructError(type, inputs[0], inputs[1]));
     } else {
         inputs.forEach(arg => {
             utils.printer(type, arg);
@@ -5859,15 +6211,15 @@ const baseLog = (type, inputs) => {
     }
 };
 
-var error = (...inputs) => baseLog('error', inputs); 
+var error = (...inputs) => baseLog('ERROR', inputs); 
 
-var warn = (...inputs) => baseLog('warn', inputs); 
+var warn = (...inputs) => baseLog('WARN', inputs); 
 
-var info = (...inputs) => baseLog('info', inputs); 
+var info = (...inputs) => baseLog('INFO', inputs); 
 
-var log = (...inputs) => baseLog('log', inputs); 
+var log = (...inputs) => baseLog('LOG', inputs); 
 
-var debug = (...inputs) => baseLog('debug', inputs); 
+var debug = (...inputs) => baseLog('DEBUG', inputs); 
 
 // only bespoke thing
 var sql = (...inputs) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@applied/applied-logger",
-  "version": "1.0.0",
+  "version": "1.1.0-rc",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2248,7 +2248,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2269,12 +2270,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2289,17 +2292,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2416,7 +2422,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2428,6 +2435,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2442,6 +2450,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2449,12 +2458,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2473,6 +2484,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2553,7 +2565,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2565,6 +2578,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2650,7 +2664,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2686,6 +2701,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2705,6 +2721,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2748,12 +2765,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@applied/applied-logger",
-  "version": "1.1.0-rc",
+  "version": "1.1.1-rc",
   "description": "",
   "main": "dist/applied-logger.cjs.js",
   "module": "dist/applied-logger.esm.js",

--- a/src/config.js
+++ b/src/config.js
@@ -3,37 +3,37 @@
 const chalk = require("chalk")
 
 module.exports = {
-    error: {
+    ERROR: {
         function: chalk.red,
         text: "🤯   [ERROR] ",
         console: message => { console.error(message) }
     },
 
-    warn: {
+    WARN: {
         function: chalk.yellow,
         text: "⚠️   [WARN]  ",
         console: message => { console.warn(message) }
     },
 
-    debug: {
+    DEBUG: {
         function: chalk.blue,
         text: "🕵️‍   [DEBUG] ",
         console: message => { console.log(message) }
     },
 
-    info: {
+    INFO: {
         function: chalk.green,
         text: "🧙‍   [INFO]  ",
         console: message => { console.info(message) }
     },
 
-    sql: {
+    SQL: {
         function: chalk.grey,
         text: "[SQLIZE] ",
         console: message => { console.log(message) }
     },
 
-    log: {
+    LOG: {
         function: chalk.magenta,
         text: "🌳  [LOG]   ",
         console: message => { console.log(message) }

--- a/src/logger.js
+++ b/src/logger.js
@@ -6,7 +6,7 @@ const utils = require('./utils')
 
 const baseLog = (type, inputs) => {
     if (utils.checkForSpecifiError(inputs)) {
-        utils.printer(type, utils.constuctError(inputs[0], inputs[1]))
+        utils.printer(type, utils.constructError(type, inputs[0], inputs[1]))
     } else {
         inputs.forEach(arg => {
             utils.printer(type, arg)
@@ -14,15 +14,15 @@ const baseLog = (type, inputs) => {
     }
 }
 
-exports.error = (...inputs) => baseLog('error', inputs) 
+exports.error = (...inputs) => baseLog('ERROR', inputs) 
 
-exports.warn = (...inputs) => baseLog('warn', inputs) 
+exports.warn = (...inputs) => baseLog('WARN', inputs) 
 
-exports.info = (...inputs) => baseLog('info', inputs) 
+exports.info = (...inputs) => baseLog('INFO', inputs) 
 
-exports.log = (...inputs) => baseLog('log', inputs) 
+exports.log = (...inputs) => baseLog('LOG', inputs) 
 
-exports.debug = (...inputs) => baseLog('debug', inputs) 
+exports.debug = (...inputs) => baseLog('DEBUG', inputs) 
 
 // only bespoke thing
 exports.sql = (...inputs) => {

--- a/src/logger.test.js
+++ b/src/logger.test.js
@@ -32,6 +32,14 @@ test("warn uses the warn pattern", () => {
     expect(console.warn.mock.calls[0][0]).toBe(chalk.yellow("⚠️   [WARN]   warn message"))
 })
 
+test("warn uses the warn pattern even if passed an error", () => {
+    expect(console.warn.mock.calls.length).toBe(0)
+    logger.warn(new Error("warn error"))
+    expect(console.warn.mock.calls.length).toBe(1)
+    expect(console.warn.mock.calls[0][0]).toContain("[WARN]")
+    expect(console.warn.mock.calls[0][0]).toContain("Error: warn error")
+})
+
 test("info uses the info pattern", () => {
     expect(console.info.mock.calls.length).toBe(0)
     logger.info("info message")

--- a/src/utils.js
+++ b/src/utils.js
@@ -21,13 +21,13 @@ exports.JSONifier = input => {
     return colorize(input, { pretty: true })
 }
 
-exports.constuctError = (err, req) => {
+exports.constructError = (type, err, req) => {
     const errJson = {
         name: err.name,
         message: err.message,
         stack: err.stack,
         context: err.context,
-        status: "ERROR"
+        status: type
     }
 
     if (req) {
@@ -49,11 +49,10 @@ exports.checkForSpecifiError = inputs => {
     return inputs.length === 2 && inputs[0] instanceof Error && !!inputs[1].url
 }
 
-exports.printer = (colorKey, input) => { /* eslint-disable-line consistent-return */
+exports.printer = (type, input) => { /* eslint-disable-line consistent-return */
+    if(!config[type]) return exports.JSONifier(input)
 
-    if(!config[colorKey]) return exports.JSONifier(input)
-
-    config[colorKey].console(
-        config[colorKey].function(`${config[colorKey].text} ${exports.JSONifier(input)}`)
+    config[type].console(
+        config[type].function(`${config[type].text} ${exports.JSONifier(input)}`)
     )
 }

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -70,7 +70,7 @@ describe('printer method', ()=>{
 
     test('it should take a key on the config and an error',()=>{
        expect(console.error.mock.calls.length).toBe(0)
-       utils.printer('error', dummyInput)
+       utils.printer('ERROR', dummyInput)
        expect(console.error.mock.calls.length).toBe(1)
        expect(console.error.mock.calls[0][0]).toContain(dummyInput)
     })
@@ -80,7 +80,7 @@ describe('printer method', ()=>{
     })
 })
 
-describe('constuctError method', ()=>{
+describe('constructError method', ()=>{
 
     const dummyErrObj =  {
         name: 'bob',
@@ -95,7 +95,7 @@ describe('constuctError method', ()=>{
     }
 
     test('it should be able to respond to an err and and err and req call',()=>{
-        expect(utils.constuctError(dummyErrObj)).toContain('i shot the sherrif')
-        expect(utils.constuctError(dummyErrObj, dummyreqObj)).toContain('somewhere@somewhere.com')
+        expect(utils.constructError("ERROR",dummyErrObj)).toContain('i shot the sherrif')
+        expect(utils.constructError("ERROR",dummyErrObj, dummyreqObj)).toContain('somewhere@somewhere.com')
     })
 })


### PR DESCRIPTION
Currently passing an error into `logger.warn` will result in `status:"ERROR"`

This change allows `logger.warn` to respect the log level specified by the client code, resulting in Datadog seeing `status:WARN`. This change is mainly because some client libraries (not naming any names, AWS) are noisy with errors and currently throw stack traces for 404s.

The only other change here is to make the internal level codes uppercase, which is in order to allow passing them straight through to the JSON log lines without needing to map values

