### PR TITLE
Make it a proper version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@applied/applied-logger",
-  "version": "1.1.1-rc",
+  "version": "1.1.1",
   "description": "",
   "main": "dist/applied-logger.cjs.js",
   "module": "dist/applied-logger.esm.js",


### PR DESCRIPTION
Is the "rc" why the app isn't picking this up?

App is looking for `^1.1.1` but this is `1.1.1-rc` which is lower so could that be the problem?